### PR TITLE
added requires for easier use

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ the appropriate JWT shared secret can be identified:
 ```ruby
 include AtlassianJwtAuthentication::Filters
 
-# will render(nothing: true, status: unauthorized) if verification fails
+# will head(:unauthorized) if verification fails
 before_filter only: [:display, :editor] do |controller|
   controller.send(:verify_jwt, 'your-add-on-key')
 end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can check out the latest source from git:
 
 Or, if you're using Bundler, just add the following to your Gemfile:
 
-    gem 'atlassian-jwt-authentication', git: 'https://github.com/MeisterLabs/atlassian-jwt-authentication.git'
+    gem 'atlassian-jwt-authentication', git: 'https://github.com/MeisterLabs/atlassian-jwt-authentication.git', require: 'atlassian_jwt_authentication'
 
 ## Usage
 

--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -57,7 +57,7 @@ module AtlassianJwtAuthentication
       return false unless _verify_jwt(addon_key, true)
 
       unless @user_context
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
@@ -77,7 +77,7 @@ module AtlassianJwtAuthentication
       if consider_param
         jwt = params[:jwt] if params[:jwt].present?
       elsif !request.headers['authorization'].present?
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
@@ -87,7 +87,7 @@ module AtlassianJwtAuthentication
       end
 
       unless jwt.present? && addon_key.present?
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
@@ -105,13 +105,13 @@ module AtlassianJwtAuthentication
       ).first
 
       unless @jwt_auth
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
       # Discard tokens without verification
       if encoding_data['alg'] == 'none'
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
@@ -129,14 +129,14 @@ module AtlassianJwtAuthentication
       decoder = JWT::Decode.new(jwt, nil, true, options)
       header, payload, signature, signing_input = decoder.decode_segments
       unless header && payload
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 
       begin
         JWT.verify_signature(encoding_data['alg'], @jwt_auth.shared_secret, signing_input, signature)
       rescue Exception => e
-        render(nothing: true, status: :unauthorized)
+        head(:unauthorized)
         return false
       end
 

--- a/lib/atlassian_jwt_authentication.rb
+++ b/lib/atlassian_jwt_authentication.rb
@@ -1,3 +1,6 @@
+require 'atlassian-jwt-authentication/filters'
+require 'atlassian-jwt-authentication/version'
+
 module AtlassianJwtAuthentication
 
 end


### PR DESCRIPTION
Thanks to this change you will not have to manually require 'atlassian-jwt-authentication/filters' in your app.
