### PR TITLE
Fixes issue reported by Atlassian

### DIFF
--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -28,6 +28,11 @@ module AtlassianJwtAuthentication
       if jwt_auth
         # The add-on was previously installed on this client
         return false unless _verify_jwt(addon_key)
+        if jwt_auth.id != current_jwt_auth.id
+          # Update request was issued to another plugin
+          head(:forbidden)
+          return false
+        end
       else
         self.current_jwt_auth = JwtToken.new(jwt_token_params)
       end


### PR DESCRIPTION
It's possible to override authentication details for a host that the request is not verified for.

To verify it run https://dl.dropboxusercontent.com/u/2052049/secret_overwrite_test.py

Remember to clean the db between script executions.