### PR TITLE
Optionally disable expiration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ bin/rails atlassian:install[prefix,username,password,https://external.address.to
 
 Where `prefix` is your instance name before `.atlassian.net`.
 
+## Environment variables
+
+`JWT_VERIFY_EXPIRATION=false` - allow expired tokens, speeds up development, espesially combined with webpack hot module reloading. 
+
 ## Requirements
 
 Ruby 2.0+, ActiveRecord 4.1+

--- a/README.md
+++ b/README.md
@@ -210,9 +210,12 @@ bin/rails atlassian:install[prefix,username,password,https://external.address.to
 
 Where `prefix` is your instance name before `.atlassian.net`.
 
-## Environment variables
+## Configuration
 
-`JWT_VERIFY_EXPIRATION=false` - allow expired tokens, speeds up development, espesially combined with webpack hot module reloading. 
+Config | Environment variable | Description | Default |
+------ | -------------------- | ----------- | ------- |
+`AtlassianJwtAuthentication.context_path` | none | server path your app is running at | `''` 
+`AtlassianJwtAuthentication.verify_jwt_expiration` | `JWT_VERIFY_EXPIRATION` | when `false` allow expired tokens, speeds up development, especially combined with webpack hot module reloading | `true` 
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ You can check out the latest source from git:
 
 Or, if you're using Bundler, just add the following to your Gemfile:
 
-    gem 'atlassian-jwt-authentication', 
-                    git: 'https://github.com/MeisterLabs/atlassian-jwt-authentication.git', 
-                    require: 'atlassian_jwt_authentication'
+```ruby
+gem 'atlassian-jwt-authentication', 
+  git: 'https://github.com/MeisterLabs/atlassian-jwt-authentication.git'
+```
 
 ## Usage
 
@@ -57,11 +58,6 @@ Don't forget to run your migrations now!
 The gem provides 2 endpoints for an Atlassian add-on lifecycle, installed and uninstalled. 
 For more information on the available Atlassian lifecycle callbacks visit 
 https://developer.atlassian.com/static/connect/docs/latest/modules/lifecycle.html.
-
-First, require the gem in one of your initializers:
-```ruby
-require 'atlassian_jwt_authentication'
-```
 
 If your add-on baseUrl is not your application root URL then include the following 
 configuration for the context path. This is needed in the query hash string validation 
@@ -160,6 +156,7 @@ response = rest_api_call(:post, '/rest/api/2/issue', data)
 pp response.success?
 
 ```
+
 
 
 ### 4. Preparing service gateways

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ pp response.success?
 ```
 
 
-
 ### 4. Preparing service gateways
 
 You can also prepare a service gateway that will encapsulate communication methods with the product. Here's a sample JIRA gateway:

--- a/lib/atlassian-jwt-authentication.rb
+++ b/lib/atlassian-jwt-authentication.rb
@@ -1,0 +1,1 @@
+require 'atlassian_jwt_authentication'

--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -144,7 +144,9 @@ module AtlassianJwtAuthentication
       end
 
       # Decode the JWT parameter without verification
-      decoded = JWT.decode(jwt, nil, false)
+      verify_expiration = ENV.fetch('JWT_VERIFY_EXPIRATION', 'true') != 'false'
+
+      decoded = JWT.decode(jwt, nil, false, {verify_expiration: verify_expiration})
 
       # Extract the data
       data = decoded[0]
@@ -171,7 +173,7 @@ module AtlassianJwtAuthentication
       # The JWT gem has changed the way you can access the decoded segments in v 1.5.5, we just handle both.
       if JWT.const_defined?(:Decode)
         options = {
-            verify_expiration: true,
+            verify_expiration: verify_expiration,
             verify_not_before: true,
             verify_iss: false,
             verify_iat: false,

--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -143,10 +143,7 @@ module AtlassianJwtAuthentication
         return false
       end
 
-      # Decode the JWT parameter without verification
-      verify_expiration = ENV.fetch('JWT_VERIFY_EXPIRATION', 'true') != 'false'
-
-      decoded = JWT.decode(jwt, nil, false, {verify_expiration: verify_expiration})
+      decoded = JWT.decode(jwt, nil, false, {verify_expiration: verify_jwt_expiration})
 
       # Extract the data
       data = decoded[0]
@@ -173,7 +170,7 @@ module AtlassianJwtAuthentication
       # The JWT gem has changed the way you can access the decoded segments in v 1.5.5, we just handle both.
       if JWT.const_defined?(:Decode)
         options = {
-            verify_expiration: verify_expiration,
+            verify_expiration: verify_jwt_expiration,
             verify_not_before: true,
             verify_iss: false,
             verify_iat: false,

--- a/lib/atlassian_jwt_authentication.rb
+++ b/lib/atlassian_jwt_authentication.rb
@@ -10,4 +10,8 @@ module AtlassianJwtAuthentication
 
   mattr_accessor :context_path
   self.context_path = ''
+
+  # Decode the JWT parameter without verification
+  mattr_accessor :verify_jwt_expiration
+  self.verify_jwt_expiration = ENV.fetch('JWT_VERIFY_EXPIRATION', 'true') != 'false'
 end


### PR DESCRIPTION
to make development easier - you can now use stale data to test out webhooks, etc.