### PR TITLE
Make qsh compatible with passing objects using url_for format

### DIFF
--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -81,7 +81,15 @@ module AtlassianJwtAuthentication
         qsh = request.method.upcase + '&' + path + '&' +
           qsh_parameters.
             sort.
-            map{ |param_pair| ERB::Util.url_encode(param_pair[0]) + '=' + ERB::Util.url_encode(param_pair[1]) }.join('&')
+            map { |(key, value)|
+              if value.respond_to?(:to_query)
+                value.to_query(key)
+              else
+                ERB::Util.url_encode(key) + '=' + ERB::Util.url_encode(value)
+              end
+            }.
+            join('&')
+
         qsh = Digest::SHA256.hexdigest(qsh)
 
         unless data['qsh'] == qsh

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -81,13 +81,7 @@ module AtlassianJwtAuthentication
         qsh = request.method.upcase + '&' + path + '&' +
           qsh_parameters.
             sort.
-            map { |(key, value)|
-              if value.respond_to?(:to_query)
-                value.to_query(key)
-              else
-                ERB::Util.url_encode(key) + '=' + ERB::Util.url_encode(value)
-              end
-            }.
+            map(&method(:encode_param)).
             join('&')
 
         qsh = Digest::SHA256.hexdigest(qsh)
@@ -123,6 +117,18 @@ module AtlassianJwtAuthentication
       end
 
       [jwt_auth, jwt_user]
+    end
+
+    private
+
+    def self.encode_param(param_pair)
+      key, value = param_pair
+
+      if value.respond_to?(:to_query)
+        value.to_query(key)
+      else
+        ERB::Util.url_encode(key) + '=' + ERB::Util.url_encode(value)
+      end
     end
   end
 end


### PR DESCRIPTION
Depends on https://github.com/MeisterLabs/atlassian-jwt-authentication/pull/20

This makes it easier to create urls using url_for notation for passing objects, for example

You can have url like that in the descriptor:

`"/panels/related_issues?issue_id={issue.id}&issue_key={issue.key}&permissions%5Badminister%5D={condition.has_global_permission(permission=ADMINISTER)}&permissions%5Bdelete_all_worklogs%5D={condition.has_project_permission(permission=DELETE_ALL_WORKLOGS)}&permissions%5Bdelete_own_worklogs%5D={condition.has_project_permission(permission=DELETE_OWN_WORKLOGS)}"`

And later you can consume permissions as an object in the code:

`params.require(:permissions).permit!`