### PR TITLE
Add account id to jwt_user (temporary workaround)

### DIFF
--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -98,15 +98,16 @@ module AtlassianJwtAuthentication
         # Has this user accessed our add-on before?
         # If not, create a new JwtUser
 
-        jwt_user = JwtUser.find_or_initialize_by(jwt_token_id: jwt_auth.id,
-          user_key: data['context']['user']['userKey']) do |user|
-          user.name = data['context']['user']['username']
-          user.display_name = data['context']['user']['displayName']
+        context_user = data['context']['user']
+        jwt_user = JwtUser.find_or_initialize_by(jwt_token_id: jwt_auth.id, user_key: context_user['userKey']) do |user|
+          user.name = context_user['username']
+          user.display_name = context_user['displayName']
+          user.account_id = context_user['accountId']
         end
 
         jwt_user.update!(
-          name: data['context']['user']['username'],
-          display_name: data['context']['user']['displayName']
+          name: context_user['username'],
+          display_name: context_user['displayName']
         )
       elsif request.params[:user_uuid]
         jwt_user = jwt_auth.jwt_users.find_by(user_key: request.params[:user_uuid])

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -107,7 +107,8 @@ module AtlassianJwtAuthentication
 
         jwt_user.update!(
           name: context_user['username'],
-          display_name: context_user['displayName']
+          display_name: context_user['displayName'],
+          account_id: jwt_user.account_id ? jwt_user.account_id : context_user['accountId']
         )
       elsif request.params[:user_uuid]
         jwt_user = jwt_auth.jwt_users.find_by(user_key: request.params[:user_uuid])

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -99,11 +99,7 @@ module AtlassianJwtAuthentication
         # If not, create a new JwtUser
 
         context_user = data['context']['user']
-        jwt_user = JwtUser.find_or_initialize_by(jwt_token_id: jwt_auth.id, user_key: context_user['userKey']) do |user|
-          user.name = context_user['username']
-          user.display_name = context_user['displayName']
-          user.account_id = context_user['accountId']
-        end
+        jwt_user = JwtUser.find_or_initialize_by(jwt_token_id: jwt_auth.id, user_key: context_user['userKey'])
 
         jwt_user.update!(
           name: context_user['username'],

--- a/lib/atlassian-jwt-authentication/version.rb
+++ b/lib/atlassian-jwt-authentication/version.rb
@@ -1,3 +1,3 @@
 module AtlassianJwtAuthentication
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/lib/generators/atlassian_jwt_authentication/templates/jwt_users_migration.rb.erb
+++ b/lib/generators/atlassian_jwt_authentication/templates/jwt_users_migration.rb.erb
@@ -8,7 +8,11 @@ class CreateAtlassianJwtUsers < ActiveRecord::Migration
         t.string :user_key
         t.string :name
         t.string :display_name
+        t.string :account_id
       end
+
+      add_index :jwt_users, [:user_key, :jwt_token_id], unique: true
+      add_index :jwt_users, [:account_id, :jwt_token_id], unique: true
     end
   end
 end


### PR DESCRIPTION
Later we should move away from jwt_user at all (or make it an optional model) but to make it useable in the transition phase I'm adding account id on jwt_user as it's already there.