### PR TITLE
One step closer GDPR compatibility

### DIFF
--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -123,6 +123,8 @@ module AtlassianJwtAuthentication
     def _verify_jwt(addon_key, consider_param = false)
       self.current_jwt_token = nil
       self.current_jwt_user = nil
+      self.current_account_id = nil
+      self.current_jwt_context = nil
 
       jwt = nil
 
@@ -141,7 +143,7 @@ module AtlassianJwtAuthentication
         jwt = possible_jwt if algorithm == 'JWT'
       end
 
-      jwt_auth, jwt_user = AtlassianJwtAuthentication::Verify.verify_jwt(addon_key, jwt, request, exclude_qsh_params)
+      jwt_auth, jwt_user, context = AtlassianJwtAuthentication::Verify.verify_jwt(addon_key, jwt, request, exclude_qsh_params)
 
       unless jwt_auth
         head(:unauthorized)
@@ -150,6 +152,8 @@ module AtlassianJwtAuthentication
 
       self.current_jwt_token = jwt_auth
       self.current_jwt_user = jwt_user
+      self.current_account_id = jwt_user&.account_id if jwt_user.respond_to?(:account_id)
+      self.current_jwt_context = context
 
       true
     end

--- a/lib/atlassian-jwt-authentication/helper.rb
+++ b/lib/atlassian-jwt-authentication/helper.rb
@@ -29,6 +29,28 @@ module AtlassianJwtAuthentication
       @jwt_user = jwt_user
     end
 
+    # Returns the current JWT context if it exists
+    def current_jwt_context
+      @jwt_context ||= session[:jwt_context]
+    end
+
+    # Sets the current JWT context
+    def current_jwt_context=(jwt_context)
+      session[:jwt_context] = jwt_context
+      @jwt_context = jwt_context
+    end
+
+    # Returns the current JWT account_id if it exists
+    def current_account_id
+      @account_id ||= session[:account_id]
+    end
+
+    # Sets the current JWT account_id
+    def current_account_id=(account_id)
+      session[:account_id] = account_id
+      @account_id = account_id
+    end
+
     def user_bearer_token(account_id, scopes)
       AtlassianJwtAuthentication::UserBearerToken::user_bearer_token(current_jwt_token, account_id, scopes)
     end

--- a/lib/atlassian-jwt-authentication/middleware.rb
+++ b/lib/atlassian-jwt-authentication/middleware.rb
@@ -5,6 +5,8 @@ module AtlassianJwtAuthentication
 
       JWT_TOKEN_HEADER = "#{PREFIX}.jwt_token".freeze
       JWT_USER_HEADER = "#{PREFIX}.jwt_user".freeze
+      JWT_CONTEXT = "#{PREFIX}.context".freeze
+      JWT_ACCOUNT_ID = "#{PREFIX}.account_id".freeze
 
       def initialize(app, addon_key)
         @app = app
@@ -22,7 +24,7 @@ module AtlassianJwtAuthentication
         end
 
         if jwt
-          jwt_auth, jwt_user = Verify.verify_jwt(@addon_key, jwt, request, [])
+          jwt_auth, jwt_user, context = Verify.verify_jwt(@addon_key, jwt, request, [])
 
           if jwt_auth
             request.set_header(JWT_TOKEN_HEADER, jwt_auth)
@@ -30,6 +32,11 @@ module AtlassianJwtAuthentication
 
           if jwt_user
             request.set_header(JWT_USER_HEADER, jwt_user)
+            request.set_header(JWT_ACCOUNT_ID, jwt_user.account_id) if jwt_user.respond_to?(:account_id)
+          end
+
+          if context
+            request.set_header(JWT_CONTEXT, context)
           end
         end
 

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -87,11 +87,12 @@ module AtlassianJwtAuthentication
         qsh = Digest::SHA256.hexdigest(qsh)
 
         unless data['qsh'] == qsh
-          return
+          return false
         end
       end
 
       jwt_user = nil
+      context = data['context']
 
       # In the case of Confluence and Jira we receive user information inside the JWT token
       if data['context'] && data['context']['user']
@@ -114,7 +115,7 @@ module AtlassianJwtAuthentication
         jwt_user = jwt_auth.jwt_users.find_by(user_key: data['sub'])
       end
 
-      [jwt_auth, jwt_user]
+      [jwt_auth, jwt_user, context]
     end
 
     private


### PR DESCRIPTION
`current_jwt_context` was added to support getting additional details from the context (if they are available).

`current_account_id` will be a replacement for `current_jwt_user` in the future (the second will be dropped).

As a followup PR I'll update current_account_id to get account_id from context or sub depending on what we get from Atlassian.

Also at some point I'll drop jwt_user and current_jwt_user.