### PR TITLE
Dependecies update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'addressable'
-gem "faraday", "~> 0.15.4"
+gem 'faraday', '~> 0.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: .
   specs:
-    atlassian-jwt-authentication (0.3.0)
+    atlassian-jwt-authentication (0.6.0)
       addressable (>= 2.4.0)
-      faraday (>= 0.15)
-      i18n (~> 1.0.1)
+      faraday (>= 0.11)
       jwt (~> 1.5)
 
 GEM
@@ -42,12 +41,12 @@ GEM
     crass (1.0.4)
     diff-lcs (1.3)
     erubi (1.7.1)
-    faraday (0.15.4)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     generator_spec (0.9.4)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
-    i18n (1.0.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jwt (1.5.6)
     loofah (2.2.3)
@@ -101,10 +100,10 @@ DEPENDENCIES
   addressable
   atlassian-jwt-authentication!
   bundler
-  faraday (~> 0.15.4)
+  faraday (~> 0.11.0)
   generator_spec
   rake
   rspec
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/atlassian_jwt_authentication.gemspec
+++ b/atlassian_jwt_authentication.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency('addressable', '>= 2.4.0')
-  s.add_dependency('faraday', '>= 0.15')
-  s.add_dependency('i18n', '~> 1.0.1')
+  s.add_dependency('faraday', '>= 0.11')
   s.add_dependency('jwt', '~> 1.5')
 
   s.add_development_dependency('activerecord', '>= 4.1.0')

--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -201,6 +201,8 @@ module AtlassianJwtAuthentication
         return false
       end
 
+      # we allow client side tokens without qsh - generated with AP.context.getToken()
+      # see https://developer.atlassian.com/cloud/jira/platform/jsapi/context/
       if data['qsh']
         # Verify the query has not been tampered by Creating a Query Hash and
         # comparing it against the qsh claim on the verified token

--- a/lib/atlassian-jwt-authentication/version.rb
+++ b/lib/atlassian-jwt-authentication/version.rb
@@ -1,3 +1,3 @@
 module AtlassianJwtAuthentication
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end


### PR DESCRIPTION
Remove i18n dependency and lower faraday dependency requirement. The faraday version was causing me hell in the repos I'm using the gem in because we're locked on a lower version with other gems.