### PR TITLE
Fix rest api call helper

### DIFF
--- a/lib/atlassian-jwt-authentication/helper.rb
+++ b/lib/atlassian-jwt-authentication/helper.rb
@@ -78,11 +78,7 @@ module AtlassianJwtAuthentication
     end
 
     def to_json_response(response)
-      if response.success?
-        Response.new(200, JSON::parse(response.body))
-      else
-        Response.new(response.status)
-      end
+        Response.new(response.status, JSON::parse(response.body))
     end
 
     class Response

--- a/lib/atlassian-jwt-authentication/helper.rb
+++ b/lib/atlassian-jwt-authentication/helper.rb
@@ -78,7 +78,8 @@ module AtlassianJwtAuthentication
     end
 
     def to_json_response(response)
-        Response.new(response.status, JSON::parse(response.body))
+        data = JSON::parse(response.body) rescue nil
+        Response.new(response.status, data)
     end
 
     class Response

--- a/lib/atlassian-jwt-authentication/helper.rb
+++ b/lib/atlassian-jwt-authentication/helper.rb
@@ -68,12 +68,11 @@ module AtlassianJwtAuthentication
 
     def rest_api_call(method, endpoint, data = nil)
       url = rest_api_url(method, endpoint)
-      options = {
-          body: data ? data.to_json : nil,
-          headers: {'Content-Type' => 'application/json'}
-      }
 
-      response = HttpClient.new(url, options).send(method)
+      response = HttpClient.new(url).send(method) do |request|
+        request.body = data ? data.to_json : nil
+        request.headers['Content-Type'] = 'application/json'
+      end
 
       to_json_response(response)
     end


### PR DESCRIPTION
The `rest_api_call` helper documented in the README did not work.  Calling it would yield
```
NoMethodError (undefined method `body' for #<Faraday::ConnectionOptions:0x00007f8246434660>)
```
Passing the body and headers in as an options has would cause this.  I think the signature to `HttpClient` was changed at some point leading to this regression.  This PR sets the body and headers using the block based approach as documented by Faraday.

Additionally, this PR makes the resulting `Response` object consistent regardless of whether there was an error.  Previously, if there was an error the response body was not returned.  This body can have valuable error messages.