### PR TITLE
Fixed bug in the code

### DIFF
--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -134,7 +134,7 @@ module AtlassianJwtAuthentication
     end
 
     def log(level, message)
-      return unless defined?(logger)
+      return if logger.nil?
 
       logger.send(level.to_sym, message)
     end


### PR DESCRIPTION
`attr_accessor :addon_key, :jwt, :request, :exclude_qsh_params, :logger` defines logger, so condition `return unless defined?(:logger)` is always true even if logger wasn't passed to the instance.

Fix that by checking if the logger is actually set before invoking a method on it.