### PR TITLE
Upgrade the JWT gem

### DIFF
--- a/atlassian_jwt_authentication.gemspec
+++ b/atlassian_jwt_authentication.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('addressable', '>= 2.4.0')
   s.add_dependency('faraday', '>= 0.11')
-  s.add_dependency('jwt', '~> 1.5')
+  s.add_dependency('jwt', '>= 2.2.1')
 
   s.add_development_dependency('activerecord', '>= 4.1.0')
   s.add_development_dependency('bundler')

--- a/lib/atlassian-jwt-authentication/version.rb
+++ b/lib/atlassian-jwt-authentication/version.rb
@@ -1,3 +1,3 @@
 module AtlassianJwtAuthentication
-  VERSION = '0.7.1'.freeze
+  VERSION = '0.7.2'.freeze
 end


### PR DESCRIPTION
Due to dependecies contraints in our repos using it I'm bumping the minimum version of the JWT gem. 
**Changes**:
- JWT.decode now needs an algorithm passed
- JWT.decode now fails if `verify_signature = true`, but no `key` is passed, which means that we can now do decoding and signature verification in a single call rather than 2