### PR TITLE
Fix the failing migration template

### DIFF
--- a/lib/generators/atlassian_jwt_authentication/templates/jwt_tokens_migration.rb.erb
+++ b/lib/generators/atlassian_jwt_authentication/templates/jwt_tokens_migration.rb.erb
@@ -1,4 +1,4 @@
-class CreateAtlassianJwtTokens < ActiveRecord::Migration
+class CreateAtlassianJwtTokens < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def self.up
     if table_exists? :jwt_tokens
       pp 'Skipping jwt_tokens table creation...'


### PR DESCRIPTION
Inheriting directly from `ActiveRecord::Migration` is no longer supported. So we need to inherit from a specific Rails version. I inherited from 6.0 as it is the most recent major release.