### PR TITLE
That's a step forward implementing newest security requirements for Atlassian Connect

### DIFF
--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -44,6 +44,7 @@ module AtlassianJwtAuthentication
       current_jwt_token.api_base_url = api_base_url if current_jwt_token.respond_to?(:api_base_url)
       current_jwt_token.oauth_client_id = params[:oauthClientId] if current_jwt_token.respond_to?(:oauth_client_id)
       current_jwt_token.public_key = params[:publicKey] if current_jwt_token.respond_to?(:public_key)
+      current_jwt_token.sen = params[:supportEntitlementNumber] if current_jwt_token.respond_to?(:sen)
       current_jwt_token.payload = params.to_unsafe_h if current_jwt_token.respond_to?(:payload)
 
       current_jwt_token.save!

--- a/lib/atlassian-jwt-authentication/middleware.rb
+++ b/lib/atlassian-jwt-authentication/middleware.rb
@@ -6,6 +6,7 @@ module AtlassianJwtAuthentication
       JWT_TOKEN_HEADER = "#{PREFIX}.jwt_token".freeze
       JWT_CONTEXT = "#{PREFIX}.context".freeze
       JWT_ACCOUNT_ID = "#{PREFIX}.account_id".freeze
+      JWT_QSH_VERIFIED = "#{PREFIX}.qsh_verified".freeze
 
       def initialize(app, addon_key)
         @app = app
@@ -23,7 +24,7 @@ module AtlassianJwtAuthentication
         end
 
         if jwt
-          jwt_auth, account_id, context = Verify.verify_jwt(@addon_key, jwt, request, [])
+          jwt_auth, account_id, context, qsh_verified = Verify.verify_jwt(@addon_key, jwt, request, [])
 
           if jwt_auth
             request.set_header(JWT_TOKEN_HEADER, jwt_auth)
@@ -35,6 +36,10 @@ module AtlassianJwtAuthentication
 
           if context
             request.set_header(JWT_CONTEXT, context)
+          end
+
+          if qsh_verified
+            request.set_header(JWT_QSH_VERIFIED, qsh_verified)
           end
         end
 

--- a/lib/atlassian-jwt-authentication/verify.rb
+++ b/lib/atlassian-jwt-authentication/verify.rb
@@ -89,6 +89,10 @@ module AtlassianJwtAuthentication
         unless data['qsh'] == qsh
           return false
         end
+
+        qsh_verified = true
+      else
+        qsh_verified = false
       end
 
       context = data['context']
@@ -100,7 +104,7 @@ module AtlassianJwtAuthentication
         account_id = data['sub']
       end
 
-      [jwt_auth, account_id, context]
+      [jwt_auth, account_id, context, qsh_verified]
     end
 
     private


### PR DESCRIPTION
`qsh_verified` can be now used to differentiate requests coming in from an iframe or via AP.request (qsh_verified will be false).

BTW congrats @bulinutza on your promotion! 🍾

Also, tell me what plans do you have for AJA? I noticed you haven't been addressing security vulnerabilities found in Atlassian Connect architecture, does that mean you're moving away from this gem? 

Or maybe you fixed them internally (as we did) without pushing to this repo?