### PR TITLE
Fixes verifying the JWT on the installed and uninstalled events

### DIFF
--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -24,17 +24,17 @@ module AtlassianJwtAuthentication
       base_url = params[:baseUrl]
       api_base_url = params[:baseApiUrl] || base_url
 
-      # All install(including upgrades)/uninstall hooks will be asymmetrically
+      # All install (including upgrades) / uninstall hooks are asymmetrically
       # signed with RS256 (RSA Signature with SHA-256) algorithm
       return false unless _verify_jwt(addon_key, force_asymmetric_verify: true)
 
       jwt_auth = JwtToken.where(client_key: client_key, addon_key: addon_key).first
-      if jwt_auth && jwt_auth.id != current_jwt_token.id
+      if jwt_auth.nil?
+        self.current_jwt_token = JwtToken.new(jwt_token_params)
+      elsif jwt_auth.id != current_jwt_token.id
         # Update request was issued to another plugin
         render_forbidden
         return false
-      elsif jwt_auth.nil?
-        self.current_jwt_token = JwtToken.new(jwt_token_params)
       end
 
       current_jwt_token.addon_key = addon_key

--- a/lib/atlassian-jwt-authentication/filters.rb
+++ b/lib/atlassian-jwt-authentication/filters.rb
@@ -24,16 +24,16 @@ module AtlassianJwtAuthentication
       base_url = params[:baseUrl]
       api_base_url = params[:baseApiUrl] || base_url
 
+      # All install(including upgrades)/uninstall hooks will be asymmetrically
+      # signed with RS256 (RSA Signature with SHA-256) algorithm
+      return false unless _verify_jwt(addon_key, force_asymmetric_verify: true)
+
       jwt_auth = JwtToken.where(client_key: client_key, addon_key: addon_key).first
-      if jwt_auth
-        # The add-on was previously installed on this client
-        return false unless _verify_jwt(addon_key)
-        if jwt_auth.id != current_jwt_token.id
-          # Update request was issued to another plugin
-          render_forbidden
-          return false
-        end
-      else
+      if jwt_auth && jwt_auth.id != current_jwt_token.id
+        # Update request was issued to another plugin
+        render_forbidden
+        return false
+      elsif jwt_auth.nil?
         self.current_jwt_token = JwtToken.new(jwt_token_params)
       end
 
@@ -55,7 +55,7 @@ module AtlassianJwtAuthentication
     def on_add_on_uninstalled
       addon_key = params[:key]
 
-      return unless _verify_jwt(addon_key)
+      return unless _verify_jwt(addon_key, force_asymmetric_verify: true)
 
       client_key = params[:clientKey]
 
@@ -67,7 +67,7 @@ module AtlassianJwtAuthentication
     end
 
     def verify_jwt(addon_key, skip_qsh_verification: false)
-      _verify_jwt(addon_key, true, skip_qsh_verification: skip_qsh_verification)
+      _verify_jwt(addon_key, consider_param: true, skip_qsh_verification: skip_qsh_verification)
     end
 
     def ensure_license
@@ -93,7 +93,7 @@ module AtlassianJwtAuthentication
         end
 
         unless response.data['state'] == 'ENABLED' &&
-            response.data['license'] && response.data['license']['active']
+          response.data['license'] && response.data['license']['active']
           log(:error, "client #{current_jwt_token.client_key}: no active & enabled license was found")
           render_payment_required
           return false
@@ -107,7 +107,7 @@ module AtlassianJwtAuthentication
 
     private
 
-    def _verify_jwt(addon_key, consider_param = false, skip_qsh_verification: false)
+    def _verify_jwt(addon_key, consider_param: false, skip_qsh_verification: false, force_asymmetric_verify: false)
       self.current_jwt_token = nil
       self.current_account_id = nil
       self.current_jwt_context = nil
@@ -130,7 +130,7 @@ module AtlassianJwtAuthentication
         jwt = possible_jwt if algorithm == 'JWT'
       end
 
-      jwt_verification = AtlassianJwtAuthentication::JWTVerification.new(addon_key, nil, nil, jwt, request)
+      jwt_verification = AtlassianJwtAuthentication::JWTVerification.new(addon_key, nil, force_asymmetric_verify, jwt, request)
       jwt_verification.exclude_qsh_params = exclude_qsh_params
       jwt_verification.logger = logger if defined?(logger)
 
@@ -150,8 +150,8 @@ module AtlassianJwtAuthentication
 
     def jwt_token_params
       {
-          client_key: params.permit(:clientKey)['clientKey'],
-          addon_key: params.permit(:key)['key']
+        client_key: params.permit(:clientKey)['clientKey'],
+        addon_key: params.permit(:key)['key']
       }
     end
 

--- a/lib/atlassian-jwt-authentication/version.rb
+++ b/lib/atlassian-jwt-authentication/version.rb
@@ -1,7 +1,7 @@
 module AtlassianJwtAuthentication
   MAJOR_VERSION = "0"
   MINOR_VERSION = "9"
-  PATH_VERSION = "1"
+  PATCH_VERSION = "1"
 
   # rubygems don't support semantic versioning - https://github.com/rubygems/rubygems/issues/592, using GITHUB_RUN_NUMBER to represent build number
   # going to release pre versions automatically
@@ -12,7 +12,7 @@ module AtlassianJwtAuthentication
       [
         MAJOR_VERSION,
         MINOR_VERSION,
-        PATH_VERSION
+        PATCH_VERSION
       ].join(".") + BUILD_NUMBER
     ).freeze
 end

--- a/lib/atlassian-jwt-authentication/version.rb
+++ b/lib/atlassian-jwt-authentication/version.rb
@@ -1,7 +1,7 @@
 module AtlassianJwtAuthentication
   MAJOR_VERSION = "0"
   MINOR_VERSION = "9"
-  PATH_VERSION = "0"
+  PATH_VERSION = "1"
 
   # rubygems don't support semantic versioning - https://github.com/rubygems/rubygems/issues/592, using GITHUB_RUN_NUMBER to represent build number
   # going to release pre versions automatically


### PR DESCRIPTION
Atlassian has changed the way they sign their JWT for the `install` and `uninstall` hooks. From their [release notes](https://community.developer.atlassian.com/t/action-required-atlassian-connect-installation-lifecycle-security-improvements/49046):

> At installation time, the Connect app server and the host product exchange a shared secret used to create and validate JWT tokens for use in API calls. However, the very first install lifecycle hook is not signed because the secret has not been shared yet to the app server. This makes it difficult to verify that the lifecycle hook was genuinely requested from Atlassian, which may lead Connect apps to be vulnerable to Denial of Service (DoS) and/or Man in the Middle(MitM) attacks and opens the possibility for further exploits when an app secret can be specified by a MitM.
> 
> Before
> - Initial install hook is not signed
> - App upgrade install hooks are symmetrically signed with previously shared secret
> - Uninstall hook is also symmetrically signed with the shared secret
> - Initial and upgrade install hooks provide shared secret which is included in its request body
> - Shared secret will be used to create and validate JWT tokens for use in API calls between Atlassian and the app including any subsequent install hooks
> 
> After
> - All install(including upgrades)/uninstall hooks will be asymmetrically signed with RS256 (RSA Signature with SHA-256) algorithm
> - Public key will be provided via a CDN to verify the JWT token. `https://connect-install-keys.atlassian.com/${public_key_id}`
> - Initial and upgrade install hooks provide shared secret which is included in its request body
> - Shared secret will be used to create and validate JWT tokens for use in API calls between Atlassian and the app, excluding install and uninstall hooks

### Main changes in this PR
- always verify the JWT in the install and uninstall hooks, because as per the documentation they're always sent now, not only on update
- use the `force_asymmetric_verify` option to verify the JWT in these 2 hooks
- minor code improvements